### PR TITLE
Use JUnit instead of uTest.

### DIFF
--- a/test-project/src/test/scala/be/doeraene/sbtdynscalajs/test/SimpleTest.scala
+++ b/test-project/src/test/scala/be/doeraene/sbtdynscalajs/test/SimpleTest.scala
@@ -1,16 +1,14 @@
 package be.doeraene.sbtdynscalajs.test
 
-import utest._
+import org.junit.Test
+import org.junit.Assert._
 
-object SimpleTest extends TestSuite {
-  val tests = Tests {
-    'trivial - {
-      assert(1 == 1)
-    }
-    "platform-dependant" - {
-      val incoming = 1.0.toString()
-      val expected = Platform.expectedDouble1toString
-      assert(incoming == expected)
-    }
+class SimpleTest {
+  @Test def trivial(): Unit = {
+    assertEquals(1, 1)
+  }
+
+  @Test def platformDependent(): Unit = {
+    assertEquals(Platform.expectedDouble1toString, 1.0.toString())
   }
 }


### PR DESCRIPTION
This makes our build independent of the releases of uTest.